### PR TITLE
Add duck animation and croissant pricing bullets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,3 +52,65 @@ h1, h2, h3, h4, h5, h6 {
 .benefit-section:last-of-type > div {
   @apply mb-10;
 }
+
+.duck-walker {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 0;
+  width: 100%;
+  pointer-events: none;
+  z-index: 30;
+  opacity: 0.95;
+}
+
+.duck-walker__track {
+  position: relative;
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  height: 110px;
+  overflow: visible;
+}
+
+.duck-walker__cross {
+  width: 130px;
+  height: 90px;
+  animation: duck-cross 24s linear infinite;
+  transform-origin: center;
+  will-change: transform;
+}
+
+.duck-walker__duck {
+  width: 130px;
+  height: 90px;
+  animation: duck-bob 1.2s ease-in-out infinite;
+  filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.12));
+}
+
+@keyframes duck-cross {
+  0% {
+    transform: translate3d(-150px, 0, 0) scaleX(1);
+  }
+  45% {
+    transform: translate3d(calc(100vw + 150px), 0, 0) scaleX(1);
+  }
+  50% {
+    transform: translate3d(calc(100vw + 150px), 0, 0) scaleX(-1);
+  }
+  95% {
+    transform: translate3d(-150px, 0, 0) scaleX(-1);
+  }
+  100% {
+    transform: translate3d(-150px, 0, 0) scaleX(1);
+  }
+}
+
+@keyframes duck-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import Container from "@/components/Container";
 import Section from "@/components/Section";
 import Stats from "@/components/Stats";
 import CTA from "@/components/CTA";
+import DuckWalker from "@/components/DuckWalker";
 
 const HomePage: React.FC = () => {
   return (
@@ -39,6 +40,7 @@ const HomePage: React.FC = () => {
         
         <CTA />
       </Container>
+      <DuckWalker />
     </>
   );
 };

--- a/src/components/DuckWalker.tsx
+++ b/src/components/DuckWalker.tsx
@@ -1,0 +1,73 @@
+const DuckIllustration = () => (
+  <svg
+    viewBox="0 0 140 90"
+    role="img"
+    aria-label="Animated duck"
+    className="w-full h-full"
+  >
+    <defs>
+      <linearGradient id="duck-body" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stopColor="#fcd34d" />
+        <stop offset="100%" stopColor="#fbbf24" />
+      </linearGradient>
+      <linearGradient id="duck-wing" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#fde68a" />
+        <stop offset="100%" stopColor="#f59e0b" />
+      </linearGradient>
+    </defs>
+    <ellipse cx="45" cy="70" rx="18" ry="8" fill="rgba(0,0,0,0.08)" />
+    <path
+      d="M58 68c5 7 20 7 27 0"
+      stroke="#f87171"
+      strokeWidth="6"
+      strokeLinecap="round"
+      fill="none"
+    />
+    <path
+      d="M20 40c-6 6-10 14-10 24 0 15 15 24 38 24 34 0 52-15 52-38 0-16-10-28-28-32"
+      fill="url(#duck-body)"
+    />
+    <path
+      d="M86 21c13 0 24 10 24 22 0 6-3 12-8 16-5 4-12 6-20 6l-7-40c3-3 7-4 11-4z"
+      fill="url(#duck-wing)"
+    />
+    <circle cx="98" cy="24" r="15" fill="#fde68a" />
+    <circle cx="106" cy="21" r="5" fill="#fff" />
+    <circle cx="108" cy="19" r="2" fill="#111827" />
+    <path
+      d="M123 30c7 0 12-4 14-9-4-2-11-4-18-3l-6 2c0 6 4 10 10 10z"
+      fill="#f97316"
+    />
+    <path
+      d="M28 80c2-5 7-8 12-8"
+      stroke="#f87171"
+      strokeWidth="6"
+      strokeLinecap="round"
+      fill="none"
+    />
+    <path
+      d="M54 80c2-5 7-8 12-8"
+      stroke="#f87171"
+      strokeWidth="6"
+      strokeLinecap="round"
+      fill="none"
+    />
+  </svg>
+);
+
+const DuckWalker: React.FC = () => {
+  return (
+    <div className="duck-walker" aria-hidden="true">
+      <div className="duck-walker__track">
+        <div className="duck-walker__cross">
+          <div className="duck-walker__duck">
+            <DuckIllustration />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DuckWalker;
+

--- a/src/components/Pricing/PricingColumn.tsx
+++ b/src/components/Pricing/PricingColumn.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { BsFillCheckCircleFill } from "react-icons/bs";
+import { GiCroissant } from "react-icons/gi";
 
 import { IPricing } from "@/types";
 
@@ -31,7 +31,10 @@ const PricingColumn: React.FC<Props> = ({ tier, highlight }: Props) => {
                 <ul className="space-y-4 mb-8">
                     {features.map((feature, index) => (
                         <li key={index} className="flex items-center">
-                            <BsFillCheckCircleFill className="h-5 w-5 text-secondary mr-2" />
+                            <GiCroissant
+                                className="h-5 w-5 text-primary mr-2"
+                                style={{ transform: "rotate(120deg)" }}
+                            />
                             <span className="text-foreground-accent">{feature}</span>
                         </li>
                     ))}

--- a/src/data/hero.ts
+++ b/src/data/hero.ts
@@ -1,5 +1,5 @@
 export const heroDetails = {
-    heading: 'Smart, Secure, Simple Financial Management',
+    heading: 'Very very good system',
     subheading: 'From effortless budgeting to real-time investment insights, Finwise puts you in control of your money like never before',
     centerImageSrc: '/images/hero-mockup.webp',
 }


### PR DESCRIPTION
**Summary**
Add DuckWalker component with SVG artwork and animation, keeping the duck fixed along the bottom edge.
Inject the duck into HomePage and add supporting styles/animations in globals.css.
Replace Pricing feature checkmarks with rotated croissant icons for a playful touch.
Update hero title copy per latest request.

**Testing**
npm run dev and load the homepage:
Duck walks across, bobbing smoothly; no layout overlap.
Pricing list shows croissant icons rotated ~120°.
Hero section reflects the new heading text.